### PR TITLE
feat: add worktree-workflow Claude Code plugin

### DIFF
--- a/claude/plugins/worktree-workflow/LICENSE
+++ b/claude/plugins/worktree-workflow/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jack Danger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/claude/plugins/worktree-workflow/README.md
+++ b/claude/plugins/worktree-workflow/README.md
@@ -1,0 +1,50 @@
+# worktree-workflow
+
+A Claude Code plugin that enforces the worktree + branch + PR pattern for all development work. No changes ever land on the main checkout.
+
+## What it does
+
+Adds a `/branch` command. Invoke it at the start of any task and Claude will:
+
+1. Create a `git worktree` + feature branch
+2. Do all file editing inside that worktree
+3. Commit, push, and open a PR
+4. Return the PR URL
+
+## Usage
+
+```
+/branch fix the audio-selection bug in gpu.rs
+```
+
+```
+/branch add Intel QSV fallback
+```
+
+Or without arguments — Claude derives the slug from your last message:
+
+```
+/branch
+```
+
+## Installation
+
+This plugin lives in the dotfiles repo. Register the dotfiles repo as a Claude Code plugin source, then install:
+
+```sh
+claude plugin add JackDanger/dotfiles --subdir claude/plugins/worktree-workflow
+```
+
+Or install directly from the local checkout:
+
+```sh
+claude plugin install ~/.dotfiles/claude/plugins/worktree-workflow
+```
+
+## Why
+
+The main worktree should always be in a known-clean state. Working in isolated worktrees means:
+- You can switch tasks without stashing
+- The main branch stays clean
+- Every task has a reviewable PR with a clear scope
+- Accidental commits to main are impossible

--- a/claude/plugins/worktree-workflow/commands/branch.md
+++ b/claude/plugins/worktree-workflow/commands/branch.md
@@ -1,0 +1,63 @@
+---
+description: Start work on a new feature by creating a git worktree + branch, then open a PR when done
+argument-hint: Short description of the task (used as branch slug)
+---
+
+# Branch: Worktree + Branch + PR Workflow
+
+You are starting development work. **Before writing any code**, create a git worktree on a new branch. All edits must happen inside that worktree, never in the primary checkout.
+
+## Rules
+
+- Never commit or stage files in the primary worktree (the repo root you were invoked from).
+- Every task gets its own worktree + branch.
+- Work ends with a PR. Summarize the PR URL to the user when done.
+
+## Steps
+
+### 1. Determine the branch name
+
+Use `$ARGUMENTS` as the slug if provided. Otherwise, derive a short kebab-case slug from the user's last message (3–5 words max). Branch name format: `<slug>`.
+
+### 2. Create the worktree
+
+```sh
+git worktree add ../<repo-basename>-<slug> <slug>
+```
+
+Where `<repo-basename>` is the last path component of the current working directory. If the branch already exists, append `-2`, `-3`, etc. to the slug until it is unique.
+
+### 3. Do all work inside the worktree
+
+All file reads, edits, and shell commands that modify code must target `../<repo-basename>-<slug>/`. Never edit files in the primary checkout.
+
+### 4. Commit in the worktree
+
+```sh
+git -C ../<repo-basename>-<slug> add <files>
+git -C ../<repo-basename>-<slug> commit -m "<message>"
+```
+
+### 5. Push and open a PR
+
+```sh
+git -C ../<repo-basename>-<slug> push -u origin <slug>
+gh pr create --title "<concise title>" --body "..." 
+```
+
+Run `gh pr create` from inside `../<repo-basename>-<slug>/`.
+
+### 6. Report back
+
+Tell the user the PR URL and the worktree path. Mention they can remove the worktree after merge:
+
+```sh
+git worktree remove ../<repo-basename>-<slug>
+git branch -d <slug>
+```
+
+---
+
+Now begin: figure out what task the user wants, create the worktree, do the work, and open the PR.
+
+Task: $ARGUMENTS


### PR DESCRIPTION
## Summary

- Adds `claude/plugins/worktree-workflow/` — a Claude Code plugin with a `/branch` command
- `/branch <description>` tells Claude to create a `git worktree` + feature branch, do all work there, commit, push, and open a PR
- Never writes to the primary checkout
- Works across all projects, not just hvac

## Why

Every session I kept having to tell Claude not to work on main. This plugin makes the correct workflow the *default* — `/branch` is the entry point for any task.

## Installation (after merge)

```sh
claude plugin install ~/.dotfiles/claude/plugins/worktree-workflow
```

## Test plan

- [ ] Review `commands/branch.md` — does it clearly describe the create/work/commit/push/PR/report loop?
- [ ] Try `/branch fix something` in a project — verify Claude creates a worktree, works there, and opens a PR
- [ ] Verify no existing dotfiles are changed (additive-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)