### PR TITLE
fix: add plugin.json manifest to worktree-workflow

### DIFF
--- a/claude/plugins/worktree-workflow/.claude-plugin/plugin.json
+++ b/claude/plugins/worktree-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "worktree-workflow",
+  "description": "Enforces worktree + branch + PR pattern for all development. /branch creates an isolated git worktree, does all work there, and opens a PR.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jack Danger",
+    "email": "anthropic@jackdanger.com"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` to `worktree-workflow`
- Required by `claude plugin validate` and the install system
- Passes validation cleanly: `✔ Validation passed`

## Install command (after merge)

```sh
claude plugin install ~/.dotfiles/claude/plugins/worktree-workflow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)