### PR TITLE
feat: add Claude Code marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "jackdanger-dotfiles",
+  "description": "Personal Claude Code plugins from Jack Danger's dotfiles",
+  "owner": {
+    "name": "Jack Danger",
+    "email": "anthropic@jackdanger.com"
+  },
+  "plugins": [
+    {
+      "name": "worktree-workflow",
+      "description": "Enforces worktree + branch + PR pattern for all development. /branch creates an isolated git worktree, does all work there, and opens a PR.",
+      "author": {
+        "name": "Jack Danger"
+      },
+      "category": "productivity",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/JackDanger/dotfiles.git",
+        "path": "claude/plugins/worktree-workflow",
+        "ref": "main",
+        "sha": "305f27da262891330e1a28ce55ccd0c4067f5a8a"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` at the dotfiles root
- Registers this repo as a Claude Code marketplace named `jackdanger-dotfiles`
- Lists `worktree-workflow` as the first plugin entry

## Install flow (after merge + pull)

```sh
claude plugin marketplace add ~/.dotfiles
claude plugin install worktree-workflow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)